### PR TITLE
Rails2 compatibility

### DIFF
--- a/representative_view.gemspec
+++ b/representative_view.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.platform = Gem::Platform::RUBY
 
   gem.add_runtime_dependency("representative", "~> 0.3.1")
-  gem.add_runtime_dependency("actionpack", "~> 3.0.1")
+  gem.add_runtime_dependency("actionpack", "> 2.3.0", "< 4.0.0")
   gem.add_runtime_dependency("nokogiri", ">= 1.4.2")
   gem.add_runtime_dependency("json", ">= 1.4.5")
 


### PR DESCRIPTION
The app I'm working on at the moment is still on Rails 2.3 but could benefit from representative_view.

I've hacked it enough to use for my immediate purpose, but I thought I'd send out a pull request early in case it's useful to someone before I get around to cleaning it up.

Looking at the number of changes, I wonder if it might make sense to split out the Rails 2 and Rails 3 support into separate files. There'll be duplication, but perhaps worth it to avoid a tangled knot of conditional logic.

Thoughts?
