### PR TITLE
fix some issue that block the test running

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'action_view'
 require 'minstrel'
 require 'representative_view'
 require 'rspec'
-
+require 'ostruct'
 require 'pathname'
 require 'fixtures/books'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ module Fixtures
     if @base.respond_to?(:template_format=) # actionpack-2
       @base.template_format = format
     elsif @base.respond_to?(:lookup_context) # actionpack-3
-      @base.lookup_context.freeze_formats([format])
+      @base.lookup_context.formats = [format]
     end
     @base.render(:file => file)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ module Fixtures
 
 end
 
-Rspec.configure do |config|
+RSpec.configure do |config|
 
   config.mock_with :rr
   config.include(Fixtures)


### PR DESCRIPTION
1. the typo error: Rspec -> RSpec.
2. should require 'ostruct' in spec when we want to use OpenStruct.
3. the method 'freeze_format' has deprecated in rails 3.2.22.5.